### PR TITLE
Use of `abi.NamedTuple` struct in getter `get_asset_config`

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -151,11 +151,11 @@
         },
         "py-algorand-sdk": {
             "hashes": [
-                "sha256:31694957ac7e23bf7bdbb84e1c640bd932fc5b808ffe4bb43fb0a2419023382c",
-                "sha256:bb24647a6fd8563f7264fc7364ba3eca8a41965afd720dd282c1c44e1dc9b050"
+                "sha256:8e49446133f0f5a4a99a586b80b886b802df9736991f877f772320402240cdb1",
+                "sha256:d72b72ab31b63b75f39c46d776631441990194de877fbb9ed70b03bd0fe4562b"
             ],
             "index": "pypi",
-            "version": "==1.16.0"
+            "version": "==1.16.1"
         },
         "pycparser": {
             "hashes": [
@@ -218,11 +218,11 @@
         },
         "pyteal": {
             "hashes": [
-                "sha256:7304a2ad5104fce6d6b7ab6495f62a8d9d95a7d19a7cd08f76c1f5e2f27e7112",
-                "sha256:d6aa6056bce0e7466c4cd478c882cc8a096e1baeafe58657ae68ddc84dd7bac6"
+                "sha256:4ea139097ae63a29f9f134d5a6dded3d8d6e3fe208f8f73f7cea41210e578e66",
+                "sha256:a36754f88b672df60f22af76f182f4077be0fc28b73ea74b627e47ea91332eb5"
             ],
             "index": "pypi",
-            "version": "==0.15.0"
+            "version": "==0.17.0"
         },
         "semantic-version": {
             "hashes": [

--- a/smart_asa_abi.json
+++ b/smart_asa_abi.json
@@ -274,10 +274,9 @@
                 }
             ],
             "returns": {
-                "type": "((uint64,uint32,bool,string,string),(string,byte[],address,address,address),(address))"
+                "type": "(uint64,uint32,bool,string,string,string,byte[],address,address,address,address)"
             }
         }
     ],
-    "desc": null,
     "networks": {}
 }

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,7 @@ from typing import Union
 from algosdk import constants
 from algosdk.future import transaction
 from algosdk.v2client import algod
+from smart_asa_asc import SmartASAConfig as PyTealSmartASAConfig
 
 
 def decode_state(state) -> dict[str, Union[int, bytes]]:
@@ -59,20 +60,8 @@ def assemble_program(algod_client: algod.AlgodClient, source_code: str) -> bytes
 
 
 SmartASAConfig = namedtuple(
-    "SmartASAConfig",
-    [
-        "total",
-        "decimals",
-        "default_frozen",
-        "unit_name",
-        "name",
-        "url",
-        "metadata_hash",
-        "manager_addr",
-        "reserve_addr",
-        "freeze_addr",
-        "clawback_addr",
-    ],
+    PyTealSmartASAConfig.__class__.__name__,
+    list(PyTealSmartASAConfig.__annotations__.keys()),
 )
 
 

--- a/utils.py
+++ b/utils.py
@@ -77,17 +77,4 @@ SmartASAConfig = namedtuple(
 
 
 def normalize_getter_params(getter_params: list) -> SmartASAConfig:
-
-    return SmartASAConfig(
-        getter_params[0],
-        getter_params[1],
-        getter_params[2],
-        getter_params[3],
-        getter_params[4],
-        getter_params[5],
-        getter_params[6],
-        getter_params[7],
-        getter_params[8],
-        getter_params[9],
-        getter_params[10],
-    )
+    return SmartASAConfig(*getter_params)

--- a/utils.py
+++ b/utils.py
@@ -81,15 +81,15 @@ SmartASAConfig = namedtuple(
 def normalize_getter_params(getter_params: list) -> SmartASAConfig:
 
     return SmartASAConfig(
-        getter_params[0][0],
-        getter_params[0][1],
-        getter_params[0][2],
-        getter_params[0][3],
-        getter_params[0][4],
-        getter_params[1][0],
-        getter_params[1][1],
-        getter_params[1][2],
-        getter_params[1][3],
-        getter_params[1][4],
-        getter_params[2][0],
+        getter_params[0],
+        getter_params[1],
+        getter_params[2],
+        getter_params[3],
+        getter_params[4],
+        getter_params[5],
+        getter_params[6],
+        getter_params[7],
+        getter_params[8],
+        getter_params[9],
+        getter_params[10],
     )

--- a/utils.py
+++ b/utils.py
@@ -58,8 +58,6 @@ def assemble_program(algod_client: algod.AlgodClient, source_code: str) -> bytes
     return base64.b64decode(compile_response["result"])
 
 
-# NOTE: getter_params represents a tuple of three tuples. This utility
-# will be removed once PyTeal integrates the ABI type NamedTuple
 SmartASAConfig = namedtuple(
     "SmartASAConfig",
     [

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 import base64
 from collections import namedtuple
+from inspect import get_annotations
 from typing import Union
 from algosdk import constants
 from algosdk.future import transaction
@@ -61,7 +62,7 @@ def assemble_program(algod_client: algod.AlgodClient, source_code: str) -> bytes
 
 SmartASAConfig = namedtuple(
     PyTealSmartASAConfig.__class__.__name__,
-    list(PyTealSmartASAConfig.__annotations__.keys()),
+    list(get_annotations(PyTealSmartASAConfig)),
 )
 
 


### PR DESCRIPTION
This PR removes the complex data struct that was using `Tuple` of `Tuples` to return a SmartASA configuration, in favor of a more elegant approach with the new abi type `NamedTuple`.  