### PR TITLE
Publishing TEAL programs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,3 @@ venv/
 
 # Debug
 dryrun.msgp
-approval.teal
-clear.teal

--- a/smart_asa_approval.teal
+++ b/smart_asa_approval.teal
@@ -1,0 +1,1547 @@
+#pragma version 6
+intcblock 0 1 8 4 65536 18446744073709551615
+bytecblock 0x736d6172745f6173615f6964 0x66726f7a656e 0x726573657276655f61646472 0x667265657a655f61646472 0x636c61776261636b5f61646472 0x151f7c75 0x6d616e616765725f61646472 0x746f74616c 0x64656661756c745f66726f7a656e 0x 0x646563696d616c73 0x756e69745f6e616d65 0x6e616d65 0x75726c 0x6d657461646174615f68617368 0x00
+txn NumAppArgs
+intc_0 // 0
+==
+bnz main_l28
+txna ApplicationArgs 0
+pushbytes 0xf80f5591 // "asset_app_optin(asset,axfer)void"
+==
+bnz main_l27
+txna ApplicationArgs 0
+pushbytes 0xe7ecd5a8 // "asset_create(uint64,uint32,bool,string,string,string,byte[],address,address,address,address)uint64"
+==
+bnz main_l26
+txna ApplicationArgs 0
+pushbytes 0xee6a84aa // "asset_config(asset,uint64,uint32,bool,string,string,string,byte[],address,address,address,address)void"
+==
+bnz main_l25
+txna ApplicationArgs 0
+pushbytes 0x2fc743a8 // "asset_transfer(asset,uint64,account,account)void"
+==
+bnz main_l24
+txna ApplicationArgs 0
+pushbytes 0x15cf2ba3 // "asset_freeze(asset,bool)void"
+==
+bnz main_l23
+txna ApplicationArgs 0
+pushbytes 0x7b351ce5 // "account_freeze(asset,account,bool)void"
+==
+bnz main_l22
+txna ApplicationArgs 0
+pushbytes 0x7dfcf38c // "asset_app_closeout(asset,account)void"
+==
+bnz main_l21
+txna ApplicationArgs 0
+pushbytes 0x4b17bf20 // "asset_destroy(asset)void"
+==
+bnz main_l20
+txna ApplicationArgs 0
+pushbytes 0x127fb717 // "get_asset_is_frozen(asset)bool"
+==
+bnz main_l19
+txna ApplicationArgs 0
+pushbytes 0x026f8a9d // "get_account_is_frozen(asset,account)bool"
+==
+bnz main_l18
+txna ApplicationArgs 0
+pushbytes 0xe97483bf // "get_circulating_supply(asset)uint64"
+==
+bnz main_l17
+txna ApplicationArgs 0
+pushbytes 0x4b8f8cf9 // "get_optin_min_balance(asset)uint64"
+==
+bnz main_l16
+txna ApplicationArgs 0
+pushbytes 0xce2f05f3 // "get_asset_config(asset)(uint64,uint32,bool,string,string,string,byte[],address,address,address,address)"
+==
+bnz main_l15
+err
+main_l15:
+txn OnCompletion
+intc_0 // NoOp
+==
+txn ApplicationID
+intc_0 // 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+intc_0 // 0
+getbyte
+callsub getassetconfig_24
+store 56
+bytec 5 // 0x151f7c75
+load 56
+concat
+log
+intc_1 // 1
+return
+main_l16:
+txn OnCompletion
+intc_0 // NoOp
+==
+txn ApplicationID
+intc_0 // 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+intc_0 // 0
+getbyte
+callsub getoptinminbalance_23
+store 55
+bytec 5 // 0x151f7c75
+load 55
+itob
+concat
+log
+intc_1 // 1
+return
+main_l17:
+txn OnCompletion
+intc_0 // NoOp
+==
+txn ApplicationID
+intc_0 // 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+intc_0 // 0
+getbyte
+callsub getcirculatingsupply_22
+store 53
+bytec 5 // 0x151f7c75
+load 53
+itob
+concat
+log
+intc_1 // 1
+return
+main_l18:
+txn OnCompletion
+intc_0 // NoOp
+==
+txn ApplicationID
+intc_0 // 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+intc_0 // 0
+getbyte
+store 49
+txna ApplicationArgs 2
+intc_0 // 0
+getbyte
+store 50
+load 49
+load 50
+callsub getaccountisfrozen_21
+store 51
+bytec 5 // 0x151f7c75
+bytec 15 // 0x00
+intc_0 // 0
+load 51
+setbit
+concat
+log
+intc_1 // 1
+return
+main_l19:
+txn OnCompletion
+intc_0 // NoOp
+==
+txn ApplicationID
+intc_0 // 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+intc_0 // 0
+getbyte
+callsub getassetisfrozen_20
+store 48
+bytec 5 // 0x151f7c75
+bytec 15 // 0x00
+intc_0 // 0
+load 48
+setbit
+concat
+log
+intc_1 // 1
+return
+main_l20:
+txn OnCompletion
+intc_0 // NoOp
+==
+txn ApplicationID
+intc_0 // 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+intc_0 // 0
+getbyte
+callsub assetdestroy_19
+intc_1 // 1
+return
+main_l21:
+txn OnCompletion
+pushint 2 // CloseOut
+==
+assert
+txna ApplicationArgs 1
+intc_0 // 0
+getbyte
+store 46
+txna ApplicationArgs 2
+intc_0 // 0
+getbyte
+store 47
+load 46
+load 47
+callsub assetappcloseout_18
+intc_1 // 1
+return
+main_l22:
+txn OnCompletion
+intc_0 // NoOp
+==
+txn ApplicationID
+intc_0 // 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+intc_0 // 0
+getbyte
+store 43
+txna ApplicationArgs 2
+intc_0 // 0
+getbyte
+store 44
+txna ApplicationArgs 3
+intc_0 // 0
+intc_2 // 8
+*
+getbit
+store 45
+load 43
+load 44
+load 45
+callsub accountfreeze_17
+intc_1 // 1
+return
+main_l23:
+txn OnCompletion
+intc_0 // NoOp
+==
+txn ApplicationID
+intc_0 // 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+intc_0 // 0
+getbyte
+store 41
+txna ApplicationArgs 2
+intc_0 // 0
+intc_2 // 8
+*
+getbit
+store 42
+load 41
+load 42
+callsub assetfreeze_16
+intc_1 // 1
+return
+main_l24:
+txn OnCompletion
+intc_0 // NoOp
+==
+txn ApplicationID
+intc_0 // 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+intc_0 // 0
+getbyte
+store 37
+txna ApplicationArgs 2
+btoi
+store 38
+txna ApplicationArgs 3
+intc_0 // 0
+getbyte
+store 39
+txna ApplicationArgs 4
+intc_0 // 0
+getbyte
+store 40
+load 37
+load 38
+load 39
+load 40
+callsub assettransfer_15
+intc_1 // 1
+return
+main_l25:
+txn OnCompletion
+intc_0 // NoOp
+==
+txn ApplicationID
+intc_0 // 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+intc_0 // 0
+getbyte
+store 25
+txna ApplicationArgs 2
+btoi
+store 26
+txna ApplicationArgs 3
+intc_0 // 0
+extract_uint32
+store 27
+txna ApplicationArgs 4
+intc_0 // 0
+intc_2 // 8
+*
+getbit
+store 28
+txna ApplicationArgs 5
+store 29
+txna ApplicationArgs 6
+store 30
+txna ApplicationArgs 7
+store 31
+txna ApplicationArgs 8
+store 32
+txna ApplicationArgs 9
+store 33
+txna ApplicationArgs 10
+store 34
+txna ApplicationArgs 11
+store 35
+txna ApplicationArgs 12
+store 36
+load 25
+load 26
+load 27
+load 28
+load 29
+load 30
+load 31
+load 32
+load 33
+load 34
+load 35
+load 36
+callsub assetconfig_14
+intc_1 // 1
+return
+main_l26:
+txn OnCompletion
+intc_0 // NoOp
+==
+txn ApplicationID
+intc_0 // 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+btoi
+store 2
+txna ApplicationArgs 2
+intc_0 // 0
+extract_uint32
+store 3
+txna ApplicationArgs 3
+intc_0 // 0
+intc_2 // 8
+*
+getbit
+store 4
+txna ApplicationArgs 4
+store 5
+txna ApplicationArgs 5
+store 6
+txna ApplicationArgs 6
+store 7
+txna ApplicationArgs 7
+store 8
+txna ApplicationArgs 8
+store 9
+txna ApplicationArgs 9
+store 10
+txna ApplicationArgs 10
+store 11
+txna ApplicationArgs 11
+store 12
+load 2
+load 3
+load 4
+load 5
+load 6
+load 7
+load 8
+load 9
+load 10
+load 11
+load 12
+callsub assetcreate_13
+store 13
+bytec 5 // 0x151f7c75
+load 13
+itob
+concat
+log
+intc_1 // 1
+return
+main_l27:
+txn OnCompletion
+intc_1 // OptIn
+==
+assert
+txna ApplicationArgs 1
+intc_0 // 0
+getbyte
+store 0
+txn GroupIndex
+intc_1 // 1
+-
+store 1
+load 1
+gtxns TypeEnum
+intc_3 // axfer
+==
+assert
+load 0
+load 1
+callsub assetappoptin_12
+intc_1 // 1
+return
+main_l28:
+txn OnCompletion
+intc_0 // NoOp
+==
+bnz main_l34
+txn OnCompletion
+intc_3 // UpdateApplication
+==
+bnz main_l33
+txn OnCompletion
+pushint 5 // DeleteApplication
+==
+bnz main_l32
+err
+main_l32:
+intc_0 // 0
+return
+main_l33:
+intc_0 // 0
+return
+main_l34:
+txn ApplicationID
+intc_0 // 0
+==
+assert
+callsub assetappcreate_11
+intc_1 // 1
+return
+
+// init_global_state
+initglobalstate_0:
+bytec_0 // "smart_asa_id"
+intc_0 // 0
+app_global_put
+bytec 7 // "total"
+intc_0 // 0
+app_global_put
+bytec 10 // "decimals"
+intc_0 // 0
+app_global_put
+bytec 8 // "default_frozen"
+intc_0 // 0
+app_global_put
+bytec 11 // "unit_name"
+bytec 9 // ""
+app_global_put
+bytec 12 // "name"
+bytec 9 // ""
+app_global_put
+bytec 13 // "url"
+bytec 9 // ""
+app_global_put
+bytec 14 // "metadata_hash"
+bytec 9 // ""
+app_global_put
+bytec 6 // "manager_addr"
+global ZeroAddress
+app_global_put
+bytec_2 // "reserve_addr"
+global ZeroAddress
+app_global_put
+bytec_3 // "freeze_addr"
+global ZeroAddress
+app_global_put
+bytec 4 // "clawback_addr"
+global ZeroAddress
+app_global_put
+bytec_1 // "frozen"
+intc_0 // 0
+app_global_put
+retsub
+
+// init_local_state
+initlocalstate_1:
+txn Sender
+bytec_0 // "smart_asa_id"
+bytec_0 // "smart_asa_id"
+app_global_get
+app_local_put
+txn Sender
+bytec_1 // "frozen"
+intc_0 // 0
+app_local_put
+retsub
+
+// digit_to_ascii
+digittoascii_2:
+store 78
+pushbytes 0x30313233343536373839 // "0123456789"
+load 78
+intc_1 // 1
+extract3
+retsub
+
+// itoa
+itoa_3:
+store 77
+load 77
+intc_0 // 0
+==
+bnz itoa_3_l5
+load 77
+pushint 10 // 10
+/
+intc_0 // 0
+>
+bnz itoa_3_l4
+bytec 9 // ""
+itoa_3_l3:
+load 77
+pushint 10 // 10
+%
+callsub digittoascii_2
+concat
+b itoa_3_l6
+itoa_3_l4:
+load 77
+pushint 10 // 10
+/
+load 77
+swap
+callsub itoa_3
+swap
+store 77
+b itoa_3_l3
+itoa_3_l5:
+pushbytes 0x30 // "0"
+itoa_3_l6:
+retsub
+
+// strip_len_prefix
+striplenprefix_4:
+extract 2 0
+retsub
+
+// underlying_asa_create_inner_tx
+underlyingasacreateinnertx_5:
+itxn_begin
+intc_0 // 0
+itxn_field Fee
+pushint 3 // acfg
+itxn_field TypeEnum
+intc 5 // 18446744073709551615
+itxn_field ConfigAssetTotal
+intc_0 // 0
+itxn_field ConfigAssetDecimals
+intc_1 // 1
+itxn_field ConfigAssetDefaultFrozen
+pushbytes 0x532d415341 // "S-ASA"
+itxn_field ConfigAssetUnitName
+pushbytes 0x534d4152542d415341 // "SMART-ASA"
+itxn_field ConfigAssetName
+pushbytes 0x736d6172742d6173612d6170702d69643a // "smart-asa-app-id:"
+global CurrentApplicationID
+callsub itoa_3
+concat
+itxn_field ConfigAssetURL
+global CurrentApplicationAddress
+itxn_field ConfigAssetManager
+global CurrentApplicationAddress
+itxn_field ConfigAssetReserve
+global CurrentApplicationAddress
+itxn_field ConfigAssetFreeze
+global CurrentApplicationAddress
+itxn_field ConfigAssetClawback
+itxn_submit
+itxn CreatedAssetID
+retsub
+
+// smart_asa_transfer_inner_txn
+smartasatransferinnertxn_6:
+store 101
+store 100
+store 99
+store 98
+itxn_begin
+intc_0 // 0
+itxn_field Fee
+intc_3 // axfer
+itxn_field TypeEnum
+load 98
+itxn_field XferAsset
+load 99
+itxn_field AssetAmount
+load 100
+itxn_field AssetSender
+load 101
+itxn_field AssetReceiver
+itxn_submit
+retsub
+
+// smart_asa_destroy_inner_txn
+smartasadestroyinnertxn_7:
+store 114
+itxn_begin
+intc_0 // 0
+itxn_field Fee
+pushint 3 // acfg
+itxn_field TypeEnum
+load 114
+itxn_field ConfigAsset
+itxn_submit
+retsub
+
+// is_valid_address_bytes_length
+isvalidaddressbyteslength_8:
+len
+pushint 32 // 32
+==
+assert
+retsub
+
+// circulating_supply
+circulatingsupply_9:
+store 91
+global CurrentApplicationAddress
+load 91
+asset_holding_get AssetBalance
+store 93
+store 92
+intc 5 // 18446744073709551615
+load 92
+-
+retsub
+
+// getter_preconditions
+getterpreconditions_10:
+store 115
+bytec_0 // "smart_asa_id"
+app_global_get
+assert
+bytec_0 // "smart_asa_id"
+app_global_get
+load 115
+==
+assert
+retsub
+
+// asset_app_create
+assetappcreate_11:
+txn GlobalNumUint
+pushint 5 // 5
+==
+assert
+txn GlobalNumByteSlice
+intc_2 // 8
+==
+assert
+txn LocalNumUint
+pushint 2 // 2
+==
+assert
+txn LocalNumByteSlice
+intc_0 // 0
+==
+assert
+callsub initglobalstate_0
+intc_1 // 1
+return
+
+// asset_app_optin
+assetappoptin_12:
+store 74
+store 73
+bytec_0 // "smart_asa_id"
+app_global_get
+assert
+bytec_0 // "smart_asa_id"
+app_global_get
+load 73
+txnas Assets
+==
+assert
+load 74
+gtxns TypeEnum
+intc_3 // axfer
+==
+assert
+load 74
+gtxns XferAsset
+bytec_0 // "smart_asa_id"
+app_global_get
+==
+assert
+load 74
+gtxns Sender
+txn Sender
+==
+assert
+load 74
+gtxns AssetReceiver
+txn Sender
+==
+assert
+load 74
+gtxns AssetAmount
+intc_0 // 0
+==
+assert
+load 74
+gtxns AssetCloseTo
+global ZeroAddress
+==
+assert
+txn Sender
+load 73
+txnas Assets
+asset_holding_get AssetBalance
+store 76
+store 75
+load 76
+assert
+callsub initlocalstate_1
+bytec 8 // "default_frozen"
+app_global_get
+load 75
+intc_0 // 0
+>
+||
+bz assetappoptin_12_l2
+txn Sender
+bytec_1 // "frozen"
+intc_1 // 1
+app_local_put
+assetappoptin_12_l2:
+intc_1 // 1
+return
+
+// asset_create
+assetcreate_13:
+store 24
+store 23
+store 22
+store 21
+store 20
+store 19
+store 18
+store 17
+store 16
+store 15
+store 14
+txn Sender
+global CreatorAddress
+==
+assert
+bytec_0 // "smart_asa_id"
+app_global_get
+!
+assert
+load 21
+callsub isvalidaddressbyteslength_8
+load 22
+callsub isvalidaddressbyteslength_8
+load 23
+callsub isvalidaddressbyteslength_8
+load 24
+callsub isvalidaddressbyteslength_8
+bytec_0 // "smart_asa_id"
+callsub underlyingasacreateinnertx_5
+app_global_put
+bytec 7 // "total"
+load 14
+app_global_put
+bytec 10 // "decimals"
+load 15
+app_global_put
+bytec 8 // "default_frozen"
+load 16
+app_global_put
+bytec 11 // "unit_name"
+load 17
+extract 2 0
+app_global_put
+bytec 12 // "name"
+load 18
+extract 2 0
+app_global_put
+bytec 13 // "url"
+load 19
+extract 2 0
+app_global_put
+bytec 14 // "metadata_hash"
+load 20
+callsub striplenprefix_4
+app_global_put
+bytec 6 // "manager_addr"
+load 21
+app_global_put
+bytec_2 // "reserve_addr"
+load 22
+app_global_put
+bytec_3 // "freeze_addr"
+load 23
+app_global_put
+bytec 4 // "clawback_addr"
+load 24
+app_global_put
+bytec_0 // "smart_asa_id"
+app_global_get
+retsub
+
+// asset_config
+assetconfig_14:
+store 90
+store 89
+store 88
+store 87
+store 86
+store 85
+store 84
+store 83
+store 82
+store 81
+store 80
+store 79
+bytec_0 // "smart_asa_id"
+app_global_get
+assert
+bytec_0 // "smart_asa_id"
+app_global_get
+load 79
+txnas Assets
+==
+assert
+load 87
+callsub isvalidaddressbyteslength_8
+load 88
+callsub isvalidaddressbyteslength_8
+load 89
+callsub isvalidaddressbyteslength_8
+load 90
+callsub isvalidaddressbyteslength_8
+txn Sender
+bytec 6 // "manager_addr"
+app_global_get
+==
+assert
+bytec_2 // "reserve_addr"
+app_global_get
+load 88
+!=
+bnz assetconfig_14_l5
+assetconfig_14_l1:
+bytec_3 // "freeze_addr"
+app_global_get
+load 89
+!=
+bnz assetconfig_14_l4
+assetconfig_14_l2:
+bytec 4 // "clawback_addr"
+app_global_get
+load 90
+!=
+bz assetconfig_14_l6
+bytec 4 // "clawback_addr"
+app_global_get
+global ZeroAddress
+!=
+assert
+b assetconfig_14_l6
+assetconfig_14_l4:
+bytec_3 // "freeze_addr"
+app_global_get
+global ZeroAddress
+!=
+assert
+b assetconfig_14_l2
+assetconfig_14_l5:
+bytec_2 // "reserve_addr"
+app_global_get
+global ZeroAddress
+!=
+assert
+b assetconfig_14_l1
+assetconfig_14_l6:
+load 80
+bytec_0 // "smart_asa_id"
+app_global_get
+callsub circulatingsupply_9
+>=
+assert
+bytec 7 // "total"
+load 80
+app_global_put
+bytec 10 // "decimals"
+load 81
+app_global_put
+bytec 8 // "default_frozen"
+load 82
+app_global_put
+bytec 11 // "unit_name"
+load 83
+extract 2 0
+app_global_put
+bytec 12 // "name"
+load 84
+extract 2 0
+app_global_put
+bytec 13 // "url"
+load 85
+extract 2 0
+app_global_put
+bytec 14 // "metadata_hash"
+load 86
+callsub striplenprefix_4
+app_global_put
+bytec 6 // "manager_addr"
+load 87
+app_global_put
+bytec_2 // "reserve_addr"
+load 88
+app_global_put
+bytec_3 // "freeze_addr"
+load 89
+app_global_put
+bytec 4 // "clawback_addr"
+load 90
+app_global_put
+retsub
+
+// asset_transfer
+assettransfer_15:
+store 97
+store 96
+store 95
+store 94
+bytec_0 // "smart_asa_id"
+app_global_get
+assert
+bytec_0 // "smart_asa_id"
+app_global_get
+load 94
+txnas Assets
+==
+assert
+load 96
+txnas Accounts
+callsub isvalidaddressbyteslength_8
+load 97
+txnas Accounts
+callsub isvalidaddressbyteslength_8
+txn Sender
+load 96
+txnas Accounts
+==
+txn Sender
+bytec 4 // "clawback_addr"
+app_global_get
+!=
+&&
+bnz assettransfer_15_l6
+txn Sender
+bytec_2 // "reserve_addr"
+app_global_get
+==
+load 96
+txnas Accounts
+global CurrentApplicationAddress
+==
+&&
+bnz assettransfer_15_l5
+txn Sender
+bytec_2 // "reserve_addr"
+app_global_get
+==
+load 96
+txnas Accounts
+bytec_2 // "reserve_addr"
+app_global_get
+==
+&&
+load 97
+txnas Accounts
+global CurrentApplicationAddress
+==
+&&
+bnz assettransfer_15_l4
+txn Sender
+bytec 4 // "clawback_addr"
+app_global_get
+==
+assert
+bytec_0 // "smart_asa_id"
+app_global_get
+load 96
+txnas Accounts
+bytec_0 // "smart_asa_id"
+app_local_get
+==
+bytec_0 // "smart_asa_id"
+app_global_get
+load 97
+txnas Accounts
+bytec_0 // "smart_asa_id"
+app_local_get
+==
+&&
+assert
+b assettransfer_15_l7
+assettransfer_15_l4:
+bytec_1 // "frozen"
+app_global_get
+!
+assert
+load 96
+txnas Accounts
+bytec_1 // "frozen"
+app_local_get
+!
+assert
+bytec_0 // "smart_asa_id"
+app_global_get
+load 96
+txnas Accounts
+bytec_0 // "smart_asa_id"
+app_local_get
+==
+assert
+b assettransfer_15_l7
+assettransfer_15_l5:
+bytec_1 // "frozen"
+app_global_get
+!
+assert
+load 97
+txnas Accounts
+bytec_1 // "frozen"
+app_local_get
+!
+assert
+bytec_0 // "smart_asa_id"
+app_global_get
+load 97
+txnas Accounts
+bytec_0 // "smart_asa_id"
+app_local_get
+==
+assert
+bytec_0 // "smart_asa_id"
+app_global_get
+callsub circulatingsupply_9
+load 95
++
+bytec 7 // "total"
+app_global_get
+<=
+assert
+b assettransfer_15_l7
+assettransfer_15_l6:
+bytec_1 // "frozen"
+app_global_get
+!
+assert
+load 96
+txnas Accounts
+bytec_1 // "frozen"
+app_local_get
+!
+assert
+load 97
+txnas Accounts
+bytec_1 // "frozen"
+app_local_get
+!
+assert
+bytec_0 // "smart_asa_id"
+app_global_get
+load 96
+txnas Accounts
+bytec_0 // "smart_asa_id"
+app_local_get
+==
+bytec_0 // "smart_asa_id"
+app_global_get
+load 97
+txnas Accounts
+bytec_0 // "smart_asa_id"
+app_local_get
+==
+&&
+assert
+assettransfer_15_l7:
+load 94
+txnas Assets
+load 95
+load 96
+txnas Accounts
+load 97
+txnas Accounts
+callsub smartasatransferinnertxn_6
+retsub
+
+// asset_freeze
+assetfreeze_16:
+store 103
+store 102
+bytec_0 // "smart_asa_id"
+app_global_get
+assert
+bytec_0 // "smart_asa_id"
+app_global_get
+load 102
+txnas Assets
+==
+assert
+txn Sender
+bytec_3 // "freeze_addr"
+app_global_get
+==
+assert
+bytec_1 // "frozen"
+load 103
+app_global_put
+retsub
+
+// account_freeze
+accountfreeze_17:
+store 106
+store 105
+store 104
+load 105
+txnas Accounts
+callsub isvalidaddressbyteslength_8
+bytec_0 // "smart_asa_id"
+app_global_get
+assert
+bytec_0 // "smart_asa_id"
+app_global_get
+load 104
+txnas Assets
+==
+assert
+txn Sender
+bytec_3 // "freeze_addr"
+app_global_get
+==
+assert
+load 105
+txnas Accounts
+bytec_1 // "frozen"
+load 106
+app_local_put
+retsub
+
+// asset_app_closeout
+assetappcloseout_18:
+store 108
+store 107
+load 108
+txnas Accounts
+callsub isvalidaddressbyteslength_8
+txn Sender
+bytec_0 // "smart_asa_id"
+app_local_get
+load 107
+txnas Assets
+==
+assert
+global GroupSize
+txn GroupIndex
+intc_1 // 1
++
+>
+assert
+txn GroupIndex
+intc_1 // 1
++
+gtxns TypeEnum
+intc_3 // axfer
+==
+assert
+txn GroupIndex
+intc_1 // 1
++
+gtxns XferAsset
+load 107
+txnas Assets
+==
+assert
+txn GroupIndex
+intc_1 // 1
++
+gtxns Sender
+txn Sender
+==
+assert
+txn GroupIndex
+intc_1 // 1
++
+gtxns AssetAmount
+intc_0 // 0
+==
+assert
+txn GroupIndex
+intc_1 // 1
++
+gtxns AssetCloseTo
+global CurrentApplicationAddress
+==
+assert
+load 107
+txnas Assets
+asset_params_get AssetCreator
+store 112
+store 111
+load 112
+bz assetappcloseout_18_l6
+bytec_0 // "smart_asa_id"
+app_global_get
+load 107
+txnas Assets
+==
+assert
+bytec_1 // "frozen"
+app_global_get
+txn Sender
+bytec_1 // "frozen"
+app_local_get
+||
+bnz assetappcloseout_18_l5
+assetappcloseout_18_l2:
+load 108
+txnas Accounts
+global CurrentApplicationAddress
+!=
+bnz assetappcloseout_18_l4
+assetappcloseout_18_l3:
+txn Sender
+load 107
+txnas Assets
+asset_holding_get AssetBalance
+store 110
+store 109
+load 107
+txnas Assets
+load 109
+txn Sender
+load 108
+txnas Accounts
+callsub smartasatransferinnertxn_6
+b assetappcloseout_18_l6
+assetappcloseout_18_l4:
+bytec_0 // "smart_asa_id"
+app_global_get
+load 108
+txnas Accounts
+bytec_0 // "smart_asa_id"
+app_local_get
+==
+assert
+b assetappcloseout_18_l3
+assetappcloseout_18_l5:
+load 108
+txnas Accounts
+global CurrentApplicationAddress
+==
+assert
+b assetappcloseout_18_l2
+assetappcloseout_18_l6:
+intc_1 // 1
+return
+
+// asset_destroy
+assetdestroy_19:
+store 113
+bytec_0 // "smart_asa_id"
+app_global_get
+assert
+bytec_0 // "smart_asa_id"
+app_global_get
+load 113
+txnas Assets
+==
+assert
+txn Sender
+bytec 6 // "manager_addr"
+app_global_get
+==
+assert
+load 113
+txnas Assets
+callsub smartasadestroyinnertxn_7
+callsub initglobalstate_0
+retsub
+
+// get_asset_is_frozen
+getassetisfrozen_20:
+txnas Assets
+callsub getterpreconditions_10
+bytec_1 // "frozen"
+app_global_get
+!
+!
+retsub
+
+// get_account_is_frozen
+getaccountisfrozen_21:
+store 52
+txnas Assets
+callsub getterpreconditions_10
+load 52
+txnas Accounts
+callsub isvalidaddressbyteslength_8
+load 52
+txnas Accounts
+bytec_1 // "frozen"
+app_local_get
+!
+!
+retsub
+
+// get_circulating_supply
+getcirculatingsupply_22:
+store 54
+load 54
+txnas Assets
+callsub getterpreconditions_10
+load 54
+txnas Assets
+callsub circulatingsupply_9
+retsub
+
+// get_optin_min_balance
+getoptinminbalance_23:
+txnas Assets
+callsub getterpreconditions_10
+pushint 157000 // 157000
+retsub
+
+// get_asset_config
+getassetconfig_24:
+txnas Assets
+callsub getterpreconditions_10
+bytec 7 // "total"
+app_global_get
+store 57
+bytec 10 // "decimals"
+app_global_get
+store 58
+load 58
+pushint 4294967296 // 4294967296
+<
+assert
+bytec 8 // "default_frozen"
+app_global_get
+!
+!
+store 59
+bytec 11 // "unit_name"
+app_global_get
+store 60
+load 60
+len
+itob
+extract 6 0
+load 60
+concat
+store 60
+bytec 12 // "name"
+app_global_get
+store 61
+load 61
+len
+itob
+extract 6 0
+load 61
+concat
+store 61
+bytec 13 // "url"
+app_global_get
+store 62
+load 62
+len
+itob
+extract 6 0
+load 62
+concat
+store 62
+bytec 14 // "metadata_hash"
+app_global_get
+store 63
+load 63
+len
+itob
+extract 6 0
+load 63
+concat
+store 63
+load 63
+store 64
+bytec 6 // "manager_addr"
+app_global_get
+store 65
+load 65
+len
+pushint 32 // 32
+==
+assert
+bytec_2 // "reserve_addr"
+app_global_get
+store 66
+load 66
+len
+pushint 32 // 32
+==
+assert
+bytec_3 // "freeze_addr"
+app_global_get
+store 67
+load 67
+len
+pushint 32 // 32
+==
+assert
+bytec 4 // "clawback_addr"
+app_global_get
+store 68
+load 68
+len
+pushint 32 // 32
+==
+assert
+load 57
+itob
+load 58
+itob
+extract 4 0
+concat
+bytec 15 // 0x00
+intc_0 // 0
+load 59
+setbit
+concat
+load 60
+store 72
+load 72
+store 71
+pushint 149 // 149
+store 69
+load 69
+load 72
+len
++
+store 70
+load 70
+intc 4 // 65536
+<
+assert
+load 69
+itob
+extract 6 0
+concat
+load 61
+store 72
+load 71
+load 72
+concat
+store 71
+load 70
+store 69
+load 69
+load 72
+len
++
+store 70
+load 70
+intc 4 // 65536
+<
+assert
+load 69
+itob
+extract 6 0
+concat
+load 62
+store 72
+load 71
+load 72
+concat
+store 71
+load 70
+store 69
+load 69
+load 72
+len
++
+store 70
+load 70
+intc 4 // 65536
+<
+assert
+load 69
+itob
+extract 6 0
+concat
+load 64
+store 72
+load 71
+load 72
+concat
+store 71
+load 70
+store 69
+load 69
+itob
+extract 6 0
+concat
+load 65
+concat
+load 66
+concat
+load 67
+concat
+load 68
+concat
+load 71
+concat
+retsub

--- a/smart_asa_clear.teal
+++ b/smart_asa_clear.teal
@@ -1,0 +1,10 @@
+#pragma version 6
+intcblock 0
+txn NumAppArgs
+intc_0 // 0
+==
+bnz main_l2
+err
+main_l2:
+intc_0 // 0
+return

--- a/smart_asa_test.py
+++ b/smart_asa_test.py
@@ -234,11 +234,11 @@ def test_compile(
         f.write(contract)
 
     print("\nAPPROVAL PROGRAM\n" + teal_approval_program)
-    with open("approval.teal", "w") as f:
+    with open("smart_asa_approval.teal", "w") as f:
         f.write(teal_approval_program)
 
     print("\nCLEAR PROGRAM\n" + teal_clear_program)
-    with open("clear.teal", "w") as f:
+    with open("smart_asa_clear.teal", "w") as f:
         f.write(teal_clear_program)
 
 


### PR DESCRIPTION
I think it is useful to provide also the TEAL Approval and Clear programs directly: this facilitates the interaction with the Smart ASA letting people deploying an App easily, without recompiling the PyTeal source code every time. In this way users can just start from TEAL programs and deploy their App (which is good for non-Python stacks).

⚠️ To be eventually merged in `develop` before #18 